### PR TITLE
[api] Upgrade flyway dependency to 9.0.3

### DIFF
--- a/openex-api/pom.xml
+++ b/openex-api/pom.xml
@@ -17,6 +17,7 @@
         <commons-validator.version>1.7</commons-validator.version>
         <springdoc.version>1.7.0</springdoc.version>
         <opensaml.version>4.1.1</opensaml.version>
+        <flyway.version>9.0.3</flyway.version>
     </properties>
 
     <profiles>
@@ -173,7 +174,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>8.5.13</version>
+            <version>${flyway.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Try to upgrade flyway to remove this warning message : 
Flyway upgrade recommended: PostgreSQL 16.0 is newer than this version of Flyway and support has not been tested. The latest supported version of PostgreSQL is 14.

For now, I am stuck with this version. I keep digging.

Ressources :
https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html